### PR TITLE
Minor spelling and style updates

### DIFF
--- a/mews-api.md
+++ b/mews-api.md
@@ -541,7 +541,7 @@ There are certain rules that need to be followed in order for Mews to process th
     * B. If the reservation is not included in the group definiton message.
 * When **cancelling** whole group, the `reservations` collection can be empty or all reservations provided as cancelled \(as per A case above\).
 
-#### Successful Request Example
+##### Successful Request Example
 
 ```javascript
 {

--- a/mews-api.md
+++ b/mews-api.md
@@ -148,7 +148,7 @@ Returns configuration of the enterprise and the client.
 
 #### Response
 
-This is example of a _successfull_ response. In case an error occurred, the response will contain only [`Error`](mews-api.md#error) object with details.
+This is example of a _successful_ response. In case an error occurred, the response will contain only [`Error`](mews-api.md#error) object with details.
 
 ```javascript
 {
@@ -540,6 +540,8 @@ There are certain rules that need to be followed in order for Mews to process th
     * A. If the `reservation`.`state` is set to [Reservation States](mews-api.md#reservation-states).`Cancelled`.
     * B. If the reservation is not included in the group definiton message.
 * When **cancelling** whole group, the `reservations` collection can be empty or all reservations provided as cancelled \(as per A case above\).
+
+#### Successful Request Example
 
 ```javascript
 {


### PR DESCRIPTION
The heading highlights that this is an example of the request.  Hopefully, it will help CHMs notice it and style their requests better so they can avoid creating so many problems during certifications because they write badly structured requests which ignore useful structures for creating complex multi-room reservations.