### PR TITLE
Delete superscript 1 from code in Reservation section

### DIFF
--- a/mews-api.md
+++ b/mews-api.md
@@ -719,7 +719,7 @@ There are certain rules that need to be followed in order for Mews to process th
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `code` | `string` | required \(always\) | Unique code of the reservation within the whole booking.¹ |
+| `code` | `string` | required \(always\) | Unique code of the reservation within the whole booking. |
 | `spaceTypeCode` | `string` | required \(exc. Cancellation\) | Space type code of the reservation. |
 | `ratePlanCode` | `string` | required \(exc. Cancellation\) | Rate type code of the reservation. |
 | `from` | `string` | required \(exc. Cancellation\) | Start date in format `"yyyy-MM-dd"` \(e.g. `"2017-12-24"` for Christmas Eve\). |


### PR DESCRIPTION
This superscript doesn't open a tooltip or other reference item.  What's it for?