### PR TITLE
Corrected /processGroup request example

### DIFF
--- a/mews-api.md
+++ b/mews-api.md
@@ -631,7 +631,7 @@ There are certain rules that need to be followed in order for Mews to process th
     "expireDate": "0818",
     "holderName": "John Smith",
     "number": "4111111111111111",
-    "type": 2
+    "type": 1
   },
   "paymentType": 1,
   "reservations": [


### PR DESCRIPTION
Payment card `type` object was for Mastercard but example card number is Visa.