### PR TITLE
Changelog update

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -14,60 +14,57 @@ For more details, see [Environments](../mews-operations/README.md#environments).
 
 # Changelog
 
-## 27 June 2022 12:00 UTC
+## 27th June 2022
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `922`.
 
-## 8 June 2022 12:00 UTC
+## 8th June 2022
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `913`.
 
-## 30 May 2022 12:00 UTC
+## 30th May 2022
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `912`.
-
-## 30 May 2022 12:00 UTC
-
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `898`.
 
-## 27 May 2022 12:00 UTC
+## 27th May 2022
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `897`.
 
-## 13 May 2022 12:00 UTC
+## 13th May 2022
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `896`.
 
-## 29 April 2022 12:00 UTC
+## 29th April 2022
 
 * [Reservation](../mews-operations/reservations.md#reservation) extended in [Process Group](../mews-operations/reservations.md#process-group). The age based pricing via `guestCounts` is now supported. Both `adultCount` and `childCount` are now deprecated.
 
-## 28 April 2022 12:00 UTC
+## 28th April 2022
 
 * Extended API operation [`getConfiguration`](../mews-operations/configuration.md#get-configuration) with [age categories](../mews-operations/configuration.md#age-categories).
 * [Inventory price updates](../channel-manager-operations/inventory.md#rate-price) extended. Age-based pricing via `agePrices` is now supported. 
 
-## 21 April 2022 12:00 UTC
+## 21st April 2022
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `881`.
 
-## 11 March 2022 12:00 UTC
+## 11th March 2022
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `877`.
 
-## 1 March 2022 12:00 UTC
+## 1st March 2022
 
 * [Customer](../mews-operations/reservations.md#customer) extended. `title` is now supported.
 
-## 21 February 2022 12:00 UTC
+## 21st February 2022
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `876`.
 
-## 17 February 2022 12:00 UTC
+## 17th February 2022
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `874`.
 
-## 28 January 2022 12:00 UTC
+## 28th January 2022
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `873`.
 

--- a/changelog/changelog2017.md
+++ b/changelog/changelog2017.md
@@ -1,13 +1,13 @@
 # Changelog 2017
 
-## 13th December 2017 00:00 UTC
+## 13th December 2017
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `425`.
 
-## 30th November 2017 00:00 UTC
+## 30th November 2017
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `423`.
 
-## 15th October 2017 22:00 UTC
+## 15th October 2017
 
 * Initial version released.

--- a/changelog/changelog2018.md
+++ b/changelog/changelog2018.md
@@ -1,42 +1,42 @@
 # Changelog 2018
 
-## 28th November 2018 22:00 UTC
+## 28th November 2018
 
 * [Restriction](../channel-manager-operations/operations.md#restriction) list supports now ClosedTo* restrictions.
 
-## 26th September 2018 22:00 UTC
+## 26th September 2018
 
 * [Channel](../channels/README.md#channels) list extended. The latest Channel added has code `739`.
 
-## 8th August 2018 22:00 UTC
+## 8th August 2018
 
 * New endpoint [Get Channels](../mews-operations/configuration.md#get-channels) added to Mews API side to obtain all [Channels](../channels/README.md#channels).
 
-## 11th July 2018 22:00 UTC
+## 11th July 2018
 
 * [Channel](../channels/README.md#channels) list extended. The latest Channel added has code `567`. Some channels were merged, because they were duplicate. All merged channels are ~~crossed~~ and the proper code is mentioned.
 
-## 18th Jun 2018 15:00 UTC
+## 18th June 2018
 
 * Mimimal required TLS version updated to `TLS 1.2`.
 
-## 31th May 2018 22:00 UTC
+## 31st May 2018
 
 * [Channel](../channels/README.md#channels) list extended. The latest Channel added has code `510`.
 
-## 9th May 2018 22:00 UTC
+## 9th May 2018
 
 * [Channel](../channels/README.md#channels) list extended. The latest Channel added has code `502`.
 
-## 18th April 2018 21:00 UTC
+## 18th April 2018
 
 * [Change Notification](../channel-manager-operations/operations.md#change-notification) extened with a `type` property of [`Change Notification Type`](../channel-manager-operations/operations.md#change-notification-type) type, that determines a type of change that happened in Mews.
 
-## 28th March 2018 22:00 UTC
+## 28th March 2018
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `500`.
 
-## 8th March 2018 22:00 UTC
+## 8th March 2018
 
 * [Process Group](../mews-operations/reservations.md#process-group) API call: following changes are done in a way that the previous fields still exist in both API and are still supported and the new fields are added next to it and used the same way as their previous versions:
 
@@ -45,19 +45,19 @@
 
 **The support is temporarily and will end approximately by end of April 2018. Make sure you migrate to use the new fields, as the previous fields will be removed.**
 
-## 1th March 2018 22:00 UTC
+## 1st March 2018
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `500`.
 
-## 7th February 2018 23:00 UTC
+## 7th February 2018
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `443`.
 
-## 18th January 2018 00:00 UTC
+## 18th January 2018
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `441`.
 
-## 10th January 2018 22:00 UTC
+## 10th January 2018
 
 * [Get Configuration](../mews-operations/configuration.md#get-configuration) API call: `applicability` field added to [`Cancellation Policy`](../mews-operations/configuration.md#cancellation-policy) object.
 Following changes are done in a way that the previous fields still exist in both API and are still supported and the new fields are added next to it and used the same way as their previous versions:

--- a/changelog/changelog2019.md
+++ b/changelog/changelog2019.md
@@ -1,10 +1,10 @@
 # Changelog 2019
 
-## 19th March 2019 22:00 UTC
+## 19th March 2019
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `819`.
 
-## 15th January 2019 22:00 UTC
+## 15th January 2019
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `740`. Some channels were merged, because they were duplicate. All merged channels are ~~crossed~~ and the proper code is mentioned.
 

--- a/changelog/changelog2020.md
+++ b/changelog/changelog2020.md
@@ -1,40 +1,40 @@
 # Changelog 2020
 
-## 8th December 2020 12:00 UTC
+## 8th December 2020
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `845`.
 
-## 27th November 2020 12:00 UTC
+## 27th November 2020
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `844`.
 
-## 10th November 2020 12:00 UTC
+## 10th November 2020
 
 * [Extra Pricing Type](../mews-operations/reservations.md#extra-pricing-types): pricing type `per person per night` added.
 
-## 20th October 2020 12:00 UTC
+## 20th October 2020
 
 * [Error codes](../guidelines/responses.md#error) list extended. New error codes are from 9 to 14.
 * [Customer](../mews-operations/reservations.md#customer) extended with loyalty code.
 
-## 20th August 2020 12:00 UTC
+## 20th August 2020
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `843`.
 
-## 1st July 2020 12:00 UTC
+## 1st July 2020
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `834`.
 
-## 27th May 2020 12:00 UTC
+## 27th May 2020
 
 * [Get Configuration](../mews-operations/configuration.md#get-configuration) extended with pricing mode, which shows whether a property is built in net or gross pricing environment.
 * [Extra](../mews-operations/reservations.md#extra) extended in [Process Group](../mews-operations/reservations.md#process-group). Consumption date can be posted for each extra sent in a reservation. 
 
-## 28th April 2020 12:00 UTC
+## 28th April 2020
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `833`.
 
-## 26th March 2020 12:00 UTC
+## 26th March 2020
 
 * [Amount](../mews-operations/reservations.md#amount) extended in [Process Group](../mews-operations/reservations.md#process-group) and [Price](../channel-manager-operations/operations.md#price) extended in [Update Prices](../channel-manager-operations/operations.md#update-prices). Net pricing is now supported for inventory upload and reservation delivery.
 

--- a/changelog/changelog2021.md
+++ b/changelog/changelog2021.md
@@ -1,43 +1,43 @@
 # Changelog 2021
 
-## 1 November 2021 12:00 UTC
+## 1st November 2021
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `872`.
 
-## 20 October 2021 12:00 UTC
+## 20th October 2021
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `871`.
 
-## 12 August 2021 12:00 UTC
+## 12th August 2021
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `870`.
 
-## 30 July 2021 12:00 UTC
+## 30th July 2021
 
 * [Space Classifications](../mews-operations/configuration.md#space-classifications) extended to support additional types with `Site`, `Office`, `MeetingRoom`, `ParkingSpot`, `Desk` and `TeamArea`.
 
-## 11 May 2021 12:00 UTC
+## 11th May 2021
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `853`.
 
-## 26 April 2021 12:00 UTC
+## 26th April 2021
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `852`.
 
-## 11th April 2021 12:00 UTC
+## 11th April 2021
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `848`.
 
-## 29th March 2021 12:00 UTC
+## 29th March 2021
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `847`.
 
-## 8th February 2021 12:00 UTC
+## 8th February 2021
 
 * [Channel](../channels/README.md) list extended. The latest Channel added has code `846`.
 
 
-## 25th January 2021 12:00 UTC
+## 25th January 2021
 
 * Added more [Restriction Examples](../channel-manager-operations/operations.md#restriction-examples).
 


### PR DESCRIPTION
Just some small changes to the Changelog date-stamp format to bring it into line with the standard used across all Mews APIs - **no functional changes to the API**.