### PR TITLE
changed home page title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Introduction
+# Mews Channel Manager API
 
 Welcome to the __Mews Channel Manager API__. This is the Mews API for distribution and sales channels, supporting two main use cases:
 distributing availability, rates and inventory data to sales channels; and accepting reservations from sales channels.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,6 +1,6 @@
 # Table of contents
 
-* [Introduction](README.md)
+* [Mews Channel Manager API](README.md)
 * [Guidelines](guidelines/README.md)
   * [Requests](guidelines/requests.md)
   * [Responses](guidelines/responses.md)


### PR DESCRIPTION
A very minor change for improved readability and to bring this API into line with the other doc sites.

* Changed home page title from 'Introduction' to 'Mews Channel Manager API'
* No Changelog entry required
