### PR TITLE
Update reservations.md

### DIFF
--- a/mews-operations/reservations.md
+++ b/mews-operations/reservations.md
@@ -384,7 +384,7 @@ The third `reservation` definition shows the partial cancellation - cancelling t
 * `Child`
 * `Teenager`
 * `Adult`
-* `Senior citizen`
+* `SeniorCitizen`
 
 #### Reservation States
 


### PR DESCRIPTION
The age category code for Seniors was incorrect. Tested in Demo and the correct is SeniorCitizen.