### PR TITLE
minor changes to Deprecations re. re-certification

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7th March 2024
+
+* Minor changes to highlight the need for re-certification when replacing deprecated features, see [Deprecations](../deprecations/README.md) (documentation only)
+
 ## 9th January 2024
 
 * Added [Age Category Code](../mews-operations/reservations.md#age-category-code) in [Mews API Operations: Process Group](../mews-operations/reservations.md#process-group) (documentation only).

--- a/channel-manager-operations/inventory.md
+++ b/channel-manager-operations/inventory.md
@@ -100,7 +100,7 @@ Mews always pushes both `gross` and `net` prices, the channel manager chooses wh
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| ~~`amount`~~ | ~~`decimal`~~ | ~~required~~ | ~~The price amount.~~ Deprecated.|
+| ~~`amount`~~ | ~~`decimal`~~ | ~~required~~ | ~~The price amount.~~ **[Deprecated!](../deprecations/README.md)** |
 | `grossAmount` | `decimal` | required | Price with taxes included. |
 | `netAmount` | `decimal` | required | Price with taxes excluded. |
 | `currencyCode` | `string` | required | The three-letter code of the rate price currency. |

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -5,7 +5,7 @@ Such features are normally deprecated because they are superseded by a better al
 The list of deprecations is as follows. Individual items are also highlighted in the [Changelog](../changelog/README.md) when they occur.
 Historic deprecations that have already been discontinued may not be listed. For more information, see our [Deprecations Policy](https://mews-systems.gitbook.io/open-api/staying-up-to-date/deprecations-policy).
 
-> **Important:** We strongly advise you to review this list and if you are using any of the deprecated items in your integration, to update your implementation accordingly.
+> **Important:** We strongly advise you to review this list and if you are using any of the deprecated items in your integration, to update your implementation accordingly and [contact Mews](mailto://partnersuccess@mews.com) for re-certification, if required.
 
 The table columns have the following meanings:
 
@@ -26,7 +26,7 @@ The table columns have the following meanings:
 | :-- | :-- | :-- | :-- |
 | `channel` in [Process group](../mews-operations/reservations.md#process-group) | Replaced by `sources` | 26 Sep 2022 | - |
 | `iata` in [Company](../mews-operations/reservations.md#company) in [Process group](../mews-operations/reservations.md#process-group) | Replaced by `iata` in the [Travel Agency](../mews-operations/reservations.md#travel-agency) object | 26 Sep 2022 | - |
-| `adultCount` and `childCount` in [`Reservation`](../mews-operations/reservations.md#reservation) object in [Process group](../mews-operations/reservations.md#process-group) | Replaced by `guestCounts` | 29 Apr 2022 | - |
+| `adultCount` and `childCount` in [`Reservation`](../mews-operations/reservations.md#reservation) object in [Process group](../mews-operations/reservations.md#process-group) | Replaced by `guestCounts`; **Requires re-certification** | 29 Apr 2022 | - |
 | `code` in [`Payment card`](../mews-operations/reservations.md#payment-card) object in [Process group](../mews-operations/reservations.md#process-group) | Replaced by `type` | 08 Mar 2018 | End Apr 2018 |
 | `accessToken` in all API calls on both Mews side and CHM side | Replaced by `clientToken` | 10 Jan 2018 | End Mar 2018 |
 | `connectionCode` in all API calls on both Mews side and CHM side | Replaced by `connectionToken` | 10 Jan 2018 | End Mar 2018 |

--- a/mews-operations/reservations.md
+++ b/mews-operations/reservations.md
@@ -246,7 +246,7 @@ The third `reservation` definition shows the partial cancellation - cancelling t
 | `paymentType` | `int` | required \(exc. Cancellation\) | [Payment Type](configuration.md#payment-types) code - determines whether the booking is prepaid or not. |
 | `customer` | [`Customer`](#customer) object | required \(exc. Cancellation\) | Represents the main booker. Does not necessarily mean that the person arrives to the property. |
 | `paymentCard` | [`Payment Card`](#payment-card) object | optional | Represents the payment card of the [`Customer`](#customer) to cover for the booking. |
-| ~~`channel`~~ | ~~[`Channel`](#channel) object~~ | ~~optional~~ | ~~Represents the channel \(i.e. Travel Agency\).~~ **Deprecated!** |
+| ~~`channel`~~ | ~~[`Channel`](#channel) object~~ | ~~optional~~ | ~~Represents the channel \(i.e. Travel Agency\).~~ **[Deprecated!](../deprecations/README.md)** |
 | `sources` | [`Source`](#source) collection | optional | Represents the sources for the booking. |
 | `company` | [`Company`](#company) object | optional | Represents the company associated with the booking. |
 | `travelAgency` | [`Travel Agency`](#travel-agency) object | optional | Represents the travel agency associated with the booking. |
@@ -279,7 +279,7 @@ The third `reservation` definition shows the partial cancellation - cancelling t
 | :-- | :-- | :-- | :-- |
 | `id` | `string` | optional | Identifier of company. |
 | `name` | `string` | optional | Name of company. |
-| ~~`iata`~~ | ~~`string`~~ | ~~optional~~ | ~~IATA number of travel agency.~~ **Deprecated!** |
+| ~~`iata`~~ | ~~`string`~~ | ~~optional~~ | ~~IATA number of travel agency.~~ **[Deprecated!](../deprecations/README.md)** |
 | `contact` | [`Contact`](#contact) object | optional | Company contact information. |
 
 #### Travel Agency
@@ -361,8 +361,8 @@ The third `reservation` definition shows the partial cancellation - cancelling t
 | `from` | `string` | required \(exc. Cancellation\) | Start date in format `"yyyy-MM-dd"` \(e.g. `"2021-12-24"` for Christmas Eve\). |
 | `to` | `string` | required \(exc. Cancellation\) | End date in format `"yyyy-MM-dd"` \(e.g. `"2021-12-31"` for New Year's Eve\). |
 | `totalAmount` | [`Amount`](#amount) object | required \(exc. Cancellation\) | Total amount of the reservation. |
-| ~~`adultCount`~~ | ~~`int`~~ | ~~required \(exc. Cancellation\)~~ | ~~Number of adults in the reservation.~~ **Deprecated!** |
-| ~~`childCount`~~ | ~~`int`~~ | ~~optional \(exc. Cancellation\)~~ | ~~Number of children in the reservation.~~ **Deprecated!** |
+| ~~`adultCount`~~ | ~~`int`~~ | ~~required \(exc. Cancellation\)~~ | ~~Number of adults in the reservation.~~ **[Deprecated!](../deprecations/README.md)** |
+| ~~`childCount`~~ | ~~`int`~~ | ~~optional \(exc. Cancellation\)~~ | ~~Number of children in the reservation.~~ **[Deprecated!](../deprecations/README.md)** |
 | `guestCounts` | array of [`Guest Count`](#guest-count) | required | Number of guests in the reservation for each age category. |
 | `state` | `int` | optional | [Reservation State](#reservation-states) code of reservation state. _If not provided, Mews will handle the reservation as `Created` or `Modified`._ |
 | `amounts` | [`Amount`](#amount) collection | required \(exc. Cancellation\) | Collection of amounts for each night of the reservation. _The count of amounts in this collection has to correspond with number of nights in the reservation._ |


### PR DESCRIPTION
Minor changes to documentation around deprecations, especially to highlight the need for re-certification where necessary.

* Updated Deprecations page important note at top of page
* Updated Deprecations page comments in entry for `guestCounts`
* Updated all **Deprecated!** labels within the API Reference to link back to the Deprecations page
