### PR TITLE
Corrected error response descriptions

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 22nd April 2024
-* Corrected error response descriptions and provided an additional example in [Guidelines > Responses](../guidelines/responses.md).
+## 15th May 2024
+* Clarified [Synchronous error response](../guidelines/responses.md#synchronous-error-response)
+* Deprecated `error` (singular) in [Synchronous error response](../guidelines/responses.md#synchronous-error-response), use `errors` (plural, array) instead. See [Deprecations](../deprecations/README.md)
 
 ## 11th April 2024
 * Added loyalty info to Request in [Channel manager API Operations: Process Availability block](../channel-manager-operations/availabilityBlock.md#availability-blockp).

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 22nd April 2024
+* Corrected error response descriptions and provided an additional example in [Guidelines > Responses](../guidelines/responses.md).
+
 ## 11th April 2024
 * Added loyalty info to Request in [Channel manager API Operations: Process Availability block](../channel-manager-operations/availabilityBlock.md#availability-blockp).
   

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -24,7 +24,7 @@ The table columns have the following meanings:
 
 | Feature | Comments | Deprecated | Discontinued |
 | :-- | :-- | :-- | :-- |
-| `error` in [Synchronous error response](../guidelines/responses.md#synchronous-error-response) | Replaced by `errors` (plural) | 15 May 2024 | - |
+| `error` in [Synchronous error response](../guidelines/responses.md#synchronous-error-response) | Replaced by `errors` (plural and an `array`) | 15 May 2024 | - |
 | `paymentType` in [`RatePlan`](../mews-operations/configuration.md#rate-plan) returned by [Mews: Get configuration](../mews-operations/configuration.md#get-configuration) | May yield incorrect value. More info below (\*1). | 16 May 2024 | - |
 | `channel` in [Process group](../mews-operations/reservations.md#process-group) | Replaced by `sources` | 26 Sep 2022 | - |
 | `iata` in [Company](../mews-operations/reservations.md#company) in [Process group](../mews-operations/reservations.md#process-group) | Replaced by `iata` in the [Travel Agency](../mews-operations/reservations.md#travel-agency) object | 26 Sep 2022 | - |

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -24,6 +24,7 @@ The table columns have the following meanings:
 
 | Feature | Comments | Deprecated | Discontinued |
 | :-- | :-- | :-- | :-- |
+| `error` in [Synchronous error response](../guidelines/responses.md#synchronous-error-response) | Replaced by `errors` (plural) | 15 May 2024 | - |
 | `channel` in [Process group](../mews-operations/reservations.md#process-group) | Replaced by `sources` | 26 Sep 2022 | - |
 | `iata` in [Company](../mews-operations/reservations.md#company) in [Process group](../mews-operations/reservations.md#process-group) | Replaced by `iata` in the [Travel Agency](../mews-operations/reservations.md#travel-agency) object | 26 Sep 2022 | - |
 | `adultCount` and `childCount` in [`Reservation`](../mews-operations/reservations.md#reservation) object in [Process group](../mews-operations/reservations.md#process-group) | Replaced by `guestCounts`; **Requires re-certification** | 29 Apr 2022 | - |

--- a/guidelines/responses.md
+++ b/guidelines/responses.md
@@ -1,10 +1,9 @@
 # Responses
 
-Each API request is expected to return a response. The **HTTP status code** of the response is `200` in case the API request processing is successful as well as if the API request processing fails, e.g. if there is an error during reservation processing, or an inventory update message fails validation.
-In case of such failures, details about the error are provided in the response body.
+Every API request is expected to yield a response. The HTTP status code of the response is `200`. This is true regardless of whether the API request processing is successful, or if it fails, e.g. due to errors during reservation processing or validation of an inventory update message. In the event of a failure, the response body contains details about the error. 
 
-> **Important:** In the case of errors with rate codes or category codes, details of the affected codes must be returned in the response body.
-> These codes will also be unsynchronized, i.e. disabled.
+> **Important:** In the event of errors involving rate codes or category codes, details of the affected codes must be returned in the response body.
+> These codes will also be unsynchronized as a result of the error, i.e. disabled.
 
 ## Synchronous simple response
 
@@ -19,8 +18,9 @@ This response object represents the default response, in case of success.
 
 ## Synchronous error response
 
-In case of error, the response object will extend the simple response object with details about the error.
-In case of errors with rate codes or category codes, details of the affected codes must also be returned.
+In case of error, the response object will extend the simple response object with details about the error or errors.
+Use the singular form `error` for a single error, and use the plural form `errors` for multiple errors.
+In case of any errors with rate codes or category codes, details of the affected codes must also be returned.
 See the [Error codes](#error-codes) table below for further details about specific errors, including guidance on system behaviour.
 
 ### Example \#1
@@ -61,11 +61,32 @@ See the [Error codes](#error-codes) table below for further details about specif
 }
 ```
 
+### Example \#4
+
+```javascript
+{
+   "success": false,
+   "errors":[
+      {
+         "code":9,
+         "message":"Invalid rate code",
+         "rateCode":"ABC"
+      },
+      {
+         "code":10,
+         "message":"Invalid category code",
+         "categoryCode":"XYZ"
+      }
+   ]
+}
+```
+
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `success` | `bool` | required | Determinines the result of the operation. |
 | `asyncConfirmation` | `bool` | optional | Determinines if there will be following asynchronous response. |
-| `errors` | array of [`Error`](#error) | optional | In case of `"success": false`, this property holds information about the errors that occurred. |
+| `error` | [`Error`](#error) | optional | In case of `"success": false`, this property holds information about the error that occurred. The singular form `error` should be used for a single error. |
+| `errors` | array of [`Error`](#error) | optional | In case of `"success": false`, this property holds information about the errors that occurred. The plural form `errors` should be used for multiple errors. |
 
 ### Error
 

--- a/guidelines/responses.md
+++ b/guidelines/responses.md
@@ -18,20 +18,19 @@ This response object represents the default response, in case of success.
 
 ## Synchronous error response
 
-In case of error, the response object will extend the simple response object with details about the error or errors.
-Use the singular form `error` for a single error, and use the plural form `errors` for multiple errors.
-In case of any errors with rate codes or category codes, details of the affected codes must also be returned.
-See the [Error codes](#error-codes) table below for further details about specific errors, including guidance on system behaviour.
+In case of error, the response object will extend the simple response object with details about the error or errors. In case of any errors with rate codes or category codes, details of the affected codes must also be returned. See the [Error codes](#error-codes) table below for further details about specific errors, including guidance on system behaviour.
 
 ### Example \#1
 
 ```javascript
 {
    "success": false,
-   "error":{
-      "code":8,
-      "message":"Invalid 'clientToken' or 'connectionToken'."
-   }
+   "errors":[
+      {
+         "code":8,
+         "message":"Invalid 'clientToken' or 'connectionToken'."
+      }
+   ]
 }
 ```
 
@@ -39,12 +38,14 @@ See the [Error codes](#error-codes) table below for further details about specif
 
 ```javascript
 {
-   "success":false,
-   "error":{
-      "code":9,
-      "message":"Invalid rate code",
-      "rateCode":"ABC"
-   }
+   "success": false,
+   "errors":[
+      {
+         "code":9,
+         "message":"Invalid rate code",
+         "rateCode":"ABC"
+      }
+   ]
 }
 ```
 
@@ -52,12 +53,14 @@ See the [Error codes](#error-codes) table below for further details about specif
 
 ```javascript
 {
-   "success":false,
-   "error":{
-      "code":10,
-      "message":"Invalid category code",
-      "categoryCode":"XYZ"
-   }
+   "success": false,
+   "errors":[
+      {
+         "code":10,
+         "message":"Invalid category code",
+         "categoryCode":"XYZ"
+      }
+   ]
 }
 ```
 
@@ -85,8 +88,8 @@ See the [Error codes](#error-codes) table below for further details about specif
 | :-- | :-- | :-- | :-- |
 | `success` | `bool` | required | Determinines the result of the operation. |
 | `asyncConfirmation` | `bool` | optional | Determinines if there will be following asynchronous response. |
-| `error` | [`Error`](#error) | optional | In case of `"success": false`, this property holds information about the error that occurred. The singular form `error` should be used for a single error. |
-| `errors` | array of [`Error`](#error) | optional | In case of `"success": false`, this property holds information about the errors that occurred. The plural form `errors` should be used for multiple errors. |
+| ~~`error`~~ | ~~[`Error`](#error)~~ | ~~optional~~ | ~~In case of `"success": false`, this property holds information about the error that occurred.~~ **[Deprecated!](../deprecations/README.md)** |
+| `errors` | array of [`Error`](#error) | optional | In case of `"success": false`, this property holds information about the error or errors that occurred. |
 
 ### Error
 


### PR DESCRIPTION
* Corrected error response descriptions in `responses.md` to include both `error` and `errors` properties
* Added fourth example to illustrate the use of `errors`
* Minor improvement to wording at the head of the page
* Ref. Asana ticket https://app.asana.com/0/1201871773388036/1207098479272602/f