### PR TITLE
Updated guidelines for channels

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 18th Sep 2024
+
+* Updated [Guidelines](../guidelines/README.md#channels) to advise how to add new sales channels or sources through the API. Documentation-only.
+
 ## 25th July 2024
 
 * Moved integration process documentation into new section [Your integration journey](../your-journey/README.md). Documentation-only.

--- a/guidelines/README.md
+++ b/guidelines/README.md
@@ -20,7 +20,8 @@ For the list of supported sales channels or sources, including Online Travel Age
 
 ### Sales channel not listed
 
-If you are connected to a sales channel which is not listed, and you are certified to use Sources, then you can add the new channel source through the API. Simply send the reservation with the named sales channel or source, using [Mews: Process group](../mews-operations/reservations.md#process-group) and the `sources` array, but leave the new source `code` value as `null`. Mews will add the new channel to the database and auto-generate a new code. To verify the new channel has been added, and to fetch the new code, use [Get channels](../mews-operations/configuration.md#get-channels). You can then use that code for future reservations as normal.
+If you are connected to a sales channel which is not listed, and you are certified to use Sources, then you can add the new channel source through the API. Simply send the reservation using [Mews: Process group](../mews-operations/reservations.md#process-group) and use the `sources` array, but when specifying the unlisted source, leave the `code` value as `null`. Take care to specify the correct `name` and `type` for the source. Mews will add the new channel to the database and auto-generate a new code for it.
+To verify the new channel has been added, and to fetch the new code, use [Get channels](../mews-operations/configuration.md#get-channels). You can then use that code for future reservations as normal.
 
 For example:
 
@@ -29,7 +30,7 @@ For example:
   {
     "code": null,
     "name": "my new source",
-    "type" : 0,
+    "type" : 6,
     "isPrimary": true
   }
 ]

--- a/guidelines/README.md
+++ b/guidelines/README.md
@@ -6,21 +6,50 @@ Here we provide general guidelines and useful links to help you through the proc
 > We use the term *Property* to describe the hotel, hostel or other enterprise; we use the term *Space* to refer to a hotel room, dormitory bed or other type of bookable space, and *Space Type* to refer to the category of *Space* offered by the *Property*. Although typically a room in a hotel, this could be for example a squash court in a sports facility.
 > For a full description of all the terms used in the API, see the [Mews Glossary for Open API users](https://help.mews.com/s/article/Mews-Glossary-for-Open-API-users?language=en_US).
 
-### Connections and tokens
+## Connections and tokens
 
 There can be multiple connections between one property and one channel manager. All API operations on both sides require `clientToken` to be present in the request. On the Mews side, `clientToken` corresponds to a specific channel manager, so the same `clientToken` should be used for all connections. On the Channel Manager side, the `clientToken` can be the same or different, as agreed between the parties, as long as `clientToken` is unique for Mews and the same for all Mews connections. All operations regarding a specific connection with a specific property require `connectionToken` as well. `connectionToken` is unique for each connection.
 
-### Channels
+## Channels
 
-For the list of supported sales channels, including Online Travel Agents or OTAs, please use the [Get channels](../mews-operations/configuration.md#get-channels) operation. If you are connected to a sales channel which is not listed, please contact Mews via [partnersuccess@mews.com](mailto://partnersuccess@mews.com) and we can update the list.
+For the list of supported sales channels or sources, including Online Travel Agents (OTAs), please use the [Get channels](../mews-operations/configuration.md#get-channels) operation.
 
-### PCI Compliance
+| <div style="width:350px">'How to' use case</div> | API Operations |
+| :-- | :-- |
+| How to get the list of sales channels or sources | [Mews: Get channels](../mews-operations/configuration.md#get-channels) |
+
+### Sales channel not listed
+
+If you are connected to a sales channel which is not listed, and you are certified to use Sources, then you can add the new channel source through the API. Simply send the reservation with the named sales channel or source, using [Mews: Process group](../mews-operations/reservations.md#process-group) and the `sources` array, but leave the new source `code` value as `null`. Mews will add the new channel to the database and auto-generate a new code. To verify the new channel has been added, and to fetch the new code, use [Get channels](../mews-operations/configuration.md#get-channels). You can then use that code for future reservations as normal.
+
+For example:
+
+```json
+"sources": [
+  {
+    "code": null,
+    "name": "my new source",
+    "type" : 0,
+    "isPrimary": true
+  }
+]
+```
+
+If you are connected to a sales channel which is not listed, but you are _not_ certified to use Sources, then please contact Mews via [partnersuccess@mews.com](mailto://partnersuccess@mews.com) and we can update the list manually.
+
+| <div style="width:350px">'How to' use case</div> | API Operations |
+| :-- | :-- |
+| How to add a new sales channel or source (if certified) | [Mews: Process group](../mews-operations/reservations.md#process-group) |
+| How to add a new sales channel or source (if _not_ certified) | Contact Mews via [partnersuccess@mews.com](mailto://partnersuccess@mews.com) |
+| How to verify the new sales channel or source | [Mews: Get channels](../mews-operations/configuration.md#get-channels) |
+
+## PCI Compliance
 
 For information on Mews PCI compliance, including current certification, please follow the links below.
 
 * [Mews PCI compliance](https://mews.force.com/s/article/pci-compliance?language=en_US)
 * [Mews PCI certificate](https://www.mews.com/en/platform-documentation)
 
-### Whitelisting
+## Whitelisting
 
 Whitelisting (also called 'allowlisting') is a common security measure which can be applied to a system to allow only specified external systems to talk to it. This has traditionally been achieved using IP address-based firewall rules. However, this approach does not work with modern cloud based architectures, which use dynamic and shared IP addresses, proxy servers and elastic resources. For this reason, we do not support the use of IP address whitelists for our APIs and we cannot supply a list of IP addresses for our APIs.


### PR DESCRIPTION
### Summary

* Updated **Channels** section in **Guidelines** to advise users how they can add new sales channels or sources automatically, without needing to contact the Partnership team