### PR TITLE
Con 4085 new field in availability block

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 7th October 2024
+## 8th October 2024
 
 * [Availability block](../channel-manager-operations/availabilityBlock.md#availability-block) extended with `pickupType` field.
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,9 @@
 ## 10th October 2024
 
 * [Availability block](../channel-manager-operations/availabilityBlock.md#availability-block) extended with `pickupType` field.
+
+## 8th October 2024
+
 * New operation [Mews: Process availability block](../mews-operations/availabilityBlock.md#process-availability-block).
 
 ## 4th October 2024

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3rd October 2024
+
+* [Availability block](../channel-manager-operations/availabilityBlock.md#availability-block) extended with `pickupType` field.
+
 ## 11th September 2024
 
 * [Restrictions](../concepts/restrictions.md) explanations re-written and moved to new section [Concepts](../concepts/README.md).

--- a/channel-manager-operations/availabilityBlock.md
+++ b/channel-manager-operations/availabilityBlock.md
@@ -114,18 +114,18 @@
 
 #### Availability block
 
-| Property             | Type                                                                      | Contract | Description                                                                                                         |
-|:---------------------|:--------------------------------------------------------------------------| :-- |:--------------------------------------------------------------------------------------------------------------------|
-| `code`               | `string`                                                                  | optional | Unique reference code from external system for the block. Will be returned after confirmation containing this code. |
-| `confirmationNumber` | `string`                                                                  | required | Mews confirmation number for the block.                                                                             |
-| `status`             | [`Status`](#status) object                                                | required | State of the block.                                                                                                 |
-| `name`               | `string`                                                                  | required | Name of the block.                                                                                                  |
-| `dates`              | [`Dates`](#dates) object                                                  | required | Dates of the block.                                                                                                 |
-| `spaceCategories`    | [`Space category allocation`](#space-category-allocation) collection      | required | Allocated categories of the block.                                                                                  |
-| `booker`             | [`Customer`](../mews-operations/reservations.md#customer) object          | required | The main booker. This does not mean that the person has arrived at the property.                                    |
-| `company`            | [`Company`](../channel-manager-operations/reservations.md#company) object | optional | The company associated with the block.                                                                              |
-| `notes`              | `string`                                                                  | optional | Notes for the block.                                                                                                |
-| `pickupType`         | [`PickupType`](#pickupType) object                                        | required | PickupType of the block.                                                                                            |
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `code` | `string` | optional | Unique reference code from external system for the block. Will be returned after confirmation containing this code. |
+| `confirmationNumber` | `string` | required | Mews confirmation number for the block. |
+| `status` | [`Status`](#status) object | required | State of the block. |
+| `name` | `string` | required | Name of the block. |
+| `dates` | [`Dates`](#dates) object | required | Dates of the block. |
+| `spaceCategories` | [`Space category allocation`](#space-category-allocation) collection | required | Allocated categories of the block. |
+| `booker` | [`Customer`](../mews-operations/reservations.md#customer) object | required | The main booker. This does not mean that the person has arrived at the property. |
+| `company` | [`Company`](../channel-manager-operations/reservations.md#company) object | optional | The company associated with the block. |
+| `notes` | `string` | optional | Notes for the block. |
+| `pickupType`| [`PickupType`](#pickupType) object | required | PickupType of the block. |
 
 #### Dates
 

--- a/channel-manager-operations/availabilityBlock.md
+++ b/channel-manager-operations/availabilityBlock.md
@@ -8,7 +8,7 @@
 
 `[ChannelManagerApiAddress]/processAvailabilityBlock`
 
-```javascript
+```json
 {
     "connectionToken": "[Token of a concrete connection]",
     "messageId": "66511e1d-2405-4e49-914b-b0c800d802c9",
@@ -99,7 +99,8 @@
             "address": null
         },
         "company": null,
-        "notes": "This is the block for Mews conference."
+        "notes": "This is the block for Mews conference.",
+        "pickupType": "AllInOneGroup"
     }  
 }
 ```
@@ -113,17 +114,18 @@
 
 #### Availability block
 
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `code` | `string` | optional | Unique reference code from external system for the block. Will be returned after confirmation containing this code. |
-| `confirmationNumber` | `string` | required | Mews confirmation number for the block. |
-| `status` | [`Status`](#status) object | required | State of the block. |
-| `name` | `string` | required | Name of the block. |
-| `dates` | [`Dates`](#dates) object | required | Dates of the block. |
-| `spaceCategories` | [`Space category allocation`](#space-category-allocation) collection | required | Allocated categories of the block. |
-| `booker` | [`Customer`](../mews-operations/reservations.md#customer) object | required | The main booker. This does not mean that the person has arrived at the property. |
-| `company` | [`Company`](../channel-manager-operations/reservations.md#company) object | optional | The company associated with the block. |
-| `notes` | `string` | optional | Notes for the block. |
+| Property             | Type                                                                      | Contract | Description                                                                                                         |
+|:---------------------|:--------------------------------------------------------------------------| :-- |:--------------------------------------------------------------------------------------------------------------------|
+| `code`               | `string`                                                                  | optional | Unique reference code from external system for the block. Will be returned after confirmation containing this code. |
+| `confirmationNumber` | `string`                                                                  | required | Mews confirmation number for the block.                                                                             |
+| `status`             | [`Status`](#status) object                                                | required | State of the block.                                                                                                 |
+| `name`               | `string`                                                                  | required | Name of the block.                                                                                                  |
+| `dates`              | [`Dates`](#dates) object                                                  | required | Dates of the block.                                                                                                 |
+| `spaceCategories`    | [`Space category allocation`](#space-category-allocation) collection      | required | Allocated categories of the block.                                                                                  |
+| `booker`             | [`Customer`](../mews-operations/reservations.md#customer) object          | required | The main booker. This does not mean that the person has arrived at the property.                                    |
+| `company`            | [`Company`](../channel-manager-operations/reservations.md#company) object | optional | The company associated with the block.                                                                              |
+| `notes`              | `string`                                                                  | optional | Notes for the block.                                                                                                |
+| `pickupType`         | [`PickupType`](#pickupType) object                                        | required | PickupType of the block.                                                                                            |
 
 #### Dates
 

--- a/channel-manager-operations/availabilityBlock.md
+++ b/channel-manager-operations/availabilityBlock.md
@@ -176,6 +176,10 @@
 * `Update`
 * `Cancel`
 
+#### PickupType
+* `AllInOneGroup`
+* `IndividualGroups`
+
 ### Response
 
 [Synchronous simple response](../guidelines/responses.md#synchronous-simple-response) is expected to determine whether the update was accepted or not.


### PR DESCRIPTION
**Release note**
https://mews.atlassian.net/browse/CON-4085: Added ability to send the flag back so they know if the availability block is All In One Group, or Individual Groups

**Summary**
Added ability to send the flag back so they know if the availability block is All In One Group, or Individual Groups updated documentation to show this new field