### PR TITLE
Added PickupType in Availability block from them to us

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,7 @@
 ## 10th October 2024
 
 * [Availability block](../channel-manager-operations/availabilityBlock.md#availability-block) extended with `pickupType` field.
+* [Availability block](../mews-operations/availabilityBlock.md#availability-block) extended with `pickupType` field.
 
 ## 8th October 2024
 

--- a/mews-operations/availabilityBlock.md
+++ b/mews-operations/availabilityBlock.md
@@ -131,7 +131,7 @@
 | `booker` | [`Customer`](./reservations.md#customer) object | required | The main booker. This does not mean that the person has arrived at the property. |
 | `company` | [`Company`](./reservations.md#company) object | optional | The company associated with the availability block. |
 | `notes` | `string` | optional | Notes related to the availability block. |
-| `pickupType`| [`PickupType`](#pickupType) object | required | PickupType of the block. |
+| `pickupType`| [`PickupType`](#pickupType) object | required | Specifies how new reservations in block should be picked up. |
 
 #### Dates
 | Property | Type | Contract | Description |

--- a/mews-operations/availabilityBlock.md
+++ b/mews-operations/availabilityBlock.md
@@ -103,7 +103,8 @@
             "address": null
         },
         "company": null,
-        "notes": "This is a note."
+        "notes": "This is a note.",
+        "pickupType": "AllInOneGroup"
     }  
 }
 ```
@@ -130,7 +131,7 @@
 | `booker` | [`Customer`](./reservations.md#customer) object | required | The main booker. This does not mean that the person has arrived at the property. |
 | `company` | [`Company`](./reservations.md#company) object | optional | The company associated with the availability block. |
 | `notes` | `string` | optional | Notes related to the availability block. |
-
+| `pickupType`| [`PickupType`](#pickupType) object | required | PickupType of the block. |
 
 #### Dates
 | Property | Type | Contract | Description |
@@ -175,6 +176,10 @@
 * `Created`
 * `Updated`
 * `Canceled`
+
+#### PickupType
+* `AllInOneGroup`
+* `IndividualGroups`
 
 #### Release strategy type
 

--- a/mews-operations/availabilityBlock.md
+++ b/mews-operations/availabilityBlock.md
@@ -178,6 +178,7 @@
 * `Canceled`
 
 #### PickupType
+
 * `AllInOneGroup`
 * `IndividualGroups`
 


### PR DESCRIPTION
**Release note**
https://mews.atlassian.net/browse/CON-4085: Added the ability for them to send us the PickupType in availability block which can be All In One Group, or Individual Groups

**Summary**
Added the ability for them to send us the PickupType in availability block which can be All In One Group, or Individual Groups