### PR TITLE
Deprecated loyaltyCode in favor of loyaltyInfo

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4th November 2024
+* Deprecated `loyaltyCode` in [Mews: Process group](../mews-operations/reservations.md#process-group). This is replaced by `loyaltyInfo`.
+
 ## 11th October 2024
 * [Mews: Process availability block](../mews-operations/availabilityBlock.md) – Added `Rolling` to release strategy type; added `offset` property to release strategy object, and updated contract and description for `fixedDate` property (NOT a breaking change)
 * [CHM: Process availability block](../channel-manager-operations/availabilityBlock.md) – Added `releasedStrategy` property to availability block object and deprecated `releasedDate` property – see [Deprecations](../deprecations/README.md).

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -24,6 +24,7 @@ The table columns have the following meanings:
 
 | Feature | Comments | Deprecated | Discontinued |
 | :-- | :-- | :-- | :-- |
+| `loyaltyCode` in [Customer](../mews-operations/reservations.md#customer) object in [Mews: Process group](../mews-operations/reservations.md#process-group) | Replaced by `loyaltyInfo` | 4 Nov 2024 | - |
 | `releasedDate` in [CHM: Dates](../channel-manager-operations/availabilityBlock.md#dates) object in [CHM: Availability block](../channel-manager-operations/availabilityBlock.md#availability-block) | Replaced by `fixedDate` in [`Release strategy`](../mews-operations/availabilityBlock.md#release-strategy) of  [`Availability block`](../channel-manager-operations/availabilityBlock.md#availability-block) | 11 Oct 2024 | - |
 | `error` in [Synchronous error response](../guidelines/responses.md#synchronous-error-response) | Replaced by `errors` (plural and an `array`) | 15 May 2024 | - |
 | `paymentType` in [`RatePlan`](../mews-operations/configuration.md#rate-plan) returned by [Mews: Get configuration](../mews-operations/configuration.md#get-configuration) | May yield incorrect value. More info below (\*1). | 16 May 2024 | - |

--- a/mews-operations/reservations.md
+++ b/mews-operations/reservations.md
@@ -267,7 +267,7 @@ The third `reservation` definition shows the partial cancellation - canceling th
 | `firstName` | `string` | optional | First name. |
 | `title` | `string` [Title](#title) | optional | Customer title, e.g. "Mister" |
 | `telephone` | `string` | optional | Telephone. |
-| `loyaltyCode` | `string` | optional |Loyalty code of the customer. Processed only for the main customer. |
+| ~~`loyaltyCode`~~ | ~~`string`~~ | ~~optional~~ | ~~Loyalty code of the customer, usually used for the customer's membership number. This is stored in Mews against the Customer Internals tab. Processed only for the main customer.~~ **[Deprecated!](../deprecations/README.md)** |
 | `loyaltyInfo` | [`Loyalty Info`](#loyalty-info) object | optional | Loyalty information of the customer. Processed only for the main customer or [`Availability block`](../channel-manager-operations/availabilityBlock.md#availability-block) booker. |
 | `nationalityCode` | `string` | optional | [ISO 3166-1 alpha-2 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) - two letter country code or [ISO 3166-1 alpha-3 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) - three letter country code. |
 | `languageCode` | `string` | optional | Language [code](https://msdn.microsoft.com/en-us/library/ee825488) of the communication language of the customer. This language will be used as the default for communication with the customer. |


### PR DESCRIPTION
As requested by TPS:

* Deprecated `loyaltyCode` in **Mews: Process group** in favor of `loyaltyInfo`, no date set for termination
* Updated description for `loyaltyCode`

I think these are the only changes needed to explain what `loyaltyCode` is and how it relates to `loyaltyInfo`. The latter is clearly a replacement that provides more specific information about the program, the tier and the membership ID.