### PR TITLE
Added limit of 100 bookings per group for Mews-side Process group

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,9 +1,15 @@
 # Changelog
 
+## 7th November 2024
+
+* [Mews: Process group](../mews-operations/reservations.md#process-group) – added recommended limit of 100 reservations per group. Documentation-only.
+
 ## 4th November 2024
+
 * Deprecated `loyaltyCode` in [Mews: Process group](../mews-operations/reservations.md#process-group). This is replaced by `loyaltyInfo`.
 
 ## 11th October 2024
+
 * [Mews: Process availability block](../mews-operations/availabilityBlock.md) – Added `Rolling` to release strategy type; added `offset` property to release strategy object, and updated contract and description for `fixedDate` property (NOT a breaking change)
 * [CHM: Process availability block](../channel-manager-operations/availabilityBlock.md) – Added `releasedStrategy` property to availability block object and deprecated `releasedDate` property – see [Deprecations](../deprecations/README.md).
 

--- a/mews-operations/reservations.md
+++ b/mews-operations/reservations.md
@@ -2,7 +2,7 @@
 
 ## Process group
 
-\[`async`\] Use this operation to push a group of reservations or bookings to Mews. The operation is called Process Group because it supports multiple options for processing on multiple groups of reservations. As well as creating new reservations in Mews, you can modify existing reservations and make cancellations, all using the same endpoint. Mews will process the requests and confirm back the reservations asynchronously.
+\[`async`\] Use this operation to push a group of reservations or bookings to Mews. The operation is called Process Group because as well as creating new reservations, you can also modify existing reservations and make cancellations, all using the same endpoint. We recommend a maximum of 100 reservations per group. Mews will process the reservation requests and confirm back the reservations asynchronously.
 
 > ### Rules to follow
 >


### PR DESCRIPTION
### Summary

* Mews: Process group – added recommended limit of 100 reservations per group
* Documentation-only
* As per Asana ticket https://app.asana.com/0/1201871773388036/1208527821731923/f
