### PR TITLE
Added reference to ISO-4217 for all currency codes

### DIFF
--- a/channel-manager-operations/availabilityBlock.md
+++ b/channel-manager-operations/availabilityBlock.md
@@ -166,7 +166,7 @@
 | :-- | :-- | :-- | :-- |
 | `start` | `string` | required | Start date in format `"yyyy-MM-dd"` \(e.g. `"2021-12-24"`\). |
 | `end` | `string` | required | End date \(excluded\) in format `"yyyy-MM-dd"` \(e.g., `"2021-12-31"`\). |
-| `currencyCode` | `string` | required | Three letter code of the currency. |
+| `currencyCode` | `string` | required | [ISO-4217](https://en.wikipedia.org/wiki/ISO_4217) three-letter currency code of the rate prices. |
 | `prices` | [`Price`](../channel-manager-operations/inventory.md#price) collection | required | Collection of prices for each person count, for the specified rate plan - space type - date combination. |        
 
 > **Dates**: Interval for 1 night (e.g. is represented 2021-12-24/25 is represented as `"start": "2021-12-24", "end": "2021-12-24"`).   

--- a/channel-manager-operations/inventory.md
+++ b/channel-manager-operations/inventory.md
@@ -127,7 +127,7 @@ Mews always pushes both `gross` and `net` prices, the channel manager chooses wh
 | :-- | :-- | :-- | :-- |
 | `grossAmount` | `decimal` | required | Price with taxes included. |
 | `netAmount` | `decimal` | required | Price with taxes excluded. |
-| `currencyCode` | `string` | required | The three-letter code of the rate price currency. |
+| `currencyCode` | `string` | required | [ISO-4217](https://en.wikipedia.org/wiki/ISO_4217) three-letter currency code of the price. |
 | `guestCount` | `int` | required | The person count for the rate price. |
 
 #### Age price
@@ -137,7 +137,7 @@ Mews always pushes both `gross` and `net` prices, the channel manager chooses wh
 | ~~`amount`~~ | ~~`decimal`~~ | ~~required~~ | ~~The price amount.~~ **[Deprecated!](../deprecations/README.md)** |
 | `grossAmount` | `decimal` | required | Price with taxes included. |
 | `netAmount` | `decimal` | required | Price with taxes excluded. |
-| `currencyCode` | `string` | required | The three-letter code of the rate price currency. |
+| `currencyCode` | `string` | required | [ISO-4217](https://en.wikipedia.org/wiki/ISO_4217) three-letter currency code of the age price. |
 | `guestCount` | `int` | required | The person count for the rate price. |
 | `ageCategoryCode` | `string` | required | Mapping code of the age category. |
 

--- a/channel-manager-operations/reservations.md
+++ b/channel-manager-operations/reservations.md
@@ -229,7 +229,7 @@ The operation supports creations, modifications, and partial or complete cancell
 | `channelManagerId` | `string` | optional | Unique identification of the booking in the channel manager. Sent always once provided by channel manager. |
 | `availabilityBlockCode` | `string` | optional | Unique identification of the availability block in the channel manager. |
 | `availabilityBlockConfirmationNumber` | `string` | optional | Unique identification of the availability block in the Mews. |
-| `currencyCode` | `string` | required \(exc. Cancellation\) | 3 letter code of currency of all prices within the booking. |
+| `currencyCode` | `string` | required \(exc. Cancellation\) | [ISO-4217](https://en.wikipedia.org/wiki/ISO_4217) three-letter currency code of all prices within the booking. |
 | `totalAmount` | [`Amount`](../mews-operations/reservations.md#amount) object | required \(exc. Cancellation\) | Total amount of the whole booking. |
 | `customer` | [`Customer`](../mews-operations/reservations.md#customer) object | required \(exc. Cancellation\) | Represents the main booker. Does not necessarily mean that the person arrives to the property. |
 | `sources` | [`Source`](../mews-operations/reservations.md#source) collection | optional | Represents the sources for the booking. |

--- a/mews-operations/configuration.md
+++ b/mews-operations/configuration.md
@@ -419,7 +419,7 @@ This is an example of a _successful_ response. In case an error occurred, the re
 | :-- | :-- | :-- | :-- |
 | `code` | `string` | required | Mapping code of the rate plan. |
 | `name` | `string` | required | Name of the rate plan. |
-| `currencyCode` | `string` | required | Three-letter currency code of the rate plan price. |
+| `currencyCode` | `string` | required | [ISO-4217](https://en.wikipedia.org/wiki/ISO_4217) three-letter currency code of the rate plan price. |
 | `description` | `string` | optional | Description of the rate plan. |
 | ~~`paymentType`~~ | ~~`int`~~ | ~~required~~ | ~~[`Payment type`](#payment-types) code.~~ [**Deprecated!**](../deprecations/README.md)|
 | `cancellationPolicies` | [`Cancellation Policy`](#cancellation-policy) collection | optional | Cancellation policies of the rate plan. |
@@ -469,7 +469,7 @@ This is an example of a _successful_ response. In case an error occurred, the re
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `amount` | `decimal` | required | Defines the amount of the absolute fee. Sent in `gross`. |
-| `currencyCode` | `string` | required | 3 letter currency code of the absolute fee. |
+| `currencyCode` | `string` | required | [ISO-4217](https://en.wikipedia.org/wiki/ISO_4217) three-letter currency code of the absolute fee. |
 
 #### Relative Cancellation Penalty
 
@@ -547,7 +547,7 @@ This is an example of a _successful_ response. In case an error occurred, the re
 | `name` | `string` | required | Name of the product. |
 | `description` | `string` | optional | Description of the product. |
 | `unitAmount` | [`Amount`](reservations.md#amount) object | required | A product cost. |
-| `currencyCode` | `string` | required | 3 letter currency code of the product. |
+| `currencyCode` | `string` | required | [ISO-4217](https://en.wikipedia.org/wiki/ISO_4217) three-letter currency code of the product. |
 | `netValue` | `decimal` | required | Tax exclusive product cost. |
 | `grossValue` | `decimal` | required | Tax inclusive product cost. |
 | `cancellationPolicies` | [`Cancellation Policy`](#cancellation-policy) collection | optional | Cancellation policies of the rate plan. |


### PR DESCRIPTION
### Summary

* Added reference to [ISO-4217](https://en.wikipedia.org/wiki/ISO_4217) for all three-letter currency codes in the API:
  * mews-operations/configuration.md (4 instances)
  * channel-manager-operations/availabilityBlock.md (1 instance)
  * channel-manager-operations/inventory.md (2 instances)
  * channel-manager-operations/reservations.md (1 instance)
* As requested in Asana https://app.asana.com/0/1201871773388036/1207645950640364/f
* I have not added a Changelog entry because it is a minor documentation-only update
